### PR TITLE
Galaxy changes

### DIFF
--- a/miRge.pl
+++ b/miRge.pl
@@ -348,7 +348,6 @@ sub runAnnotationPipeline {
 		# run alignment
 		print "Starting Annotation-$$annotNames[$i] ";
 		$$logHash{'annotStats'}[$i+1]{'cpuTime'} = time;
-        print STDERR "$$bwtCmdLines[$i]\n";
 		$alignmentStatus = system($$bwtCmdLines[$i]);
 		$$logHash{'annotStats'}[$i+1]{'cpuTime'} = time - $$logHash{'annotStats'}[$i+1]{'cpuTime'}; # in seconds
 		$alignmentStatus = $alignmentStatus >> 8;
@@ -493,7 +492,6 @@ sub summarize {
 }
 
 sub miRNAmerge {
-	my $mergeFile;
 	my $fh;
 	my $line;
 	my $i;
@@ -629,7 +627,7 @@ sub generateGraphs {
 }
 
 sub writeHtmlReport {
-	my $filename = $outputHTML;#$outputPath.'/'.$outputHTML;
+	my $filename = ($$settings{outputHTML}) ? $outputHTML : $outputPath . "/" . $outputHTML;
 	my $fh;
 	my $i;
 	my $annotTable = new HTML::Table(0,0);
@@ -673,6 +671,10 @@ sub writeHtmlReport {
     $fileTable->addRow('<a href="miR.RPM.csv">miRNA RPM</a>');
     $fileTable->addRow('<a href="mapped.csv">miRNA mapped</a>');
     $fileTable->addRow('<a href="unmapped.csv">miRNA unmapped</a>');
+    if($isomirDiff){
+        $fileTable->addRow('<a href="isomirs.csv">miRNA isomirs</a>');
+        $fileTable->addRow('<a href="isomirs.samples.csv">miRNA isomirs samples</a>');
+    }
 	open $fh, ">", $filename;
 	print $fh htmlHeader();
 	print $fh "<h1>miRge Results</h1>\n<h2>Sample Result(s)</h2>\n";

--- a/miRge.pl
+++ b/miRge.pl
@@ -546,7 +546,7 @@ sub filter {
 	
 	for ($i=0; $i<scalar(@sampleFiles); $i++) {
 		if($$logHash{'quantStats'}[$i]{'mirnaReadsFiltered'} == 0){
-			die "No miRNA reads were found in sample $sampleFiles[$i]. Please check your files and provided arguments.\n";
+			print STDERR "Warning: No miRNA reads were found in sample $sampleFiles[$i]. Please check your files and provided arguments.\n";
 		}
 	}
 }

--- a/miRge.pl
+++ b/miRge.pl
@@ -322,7 +322,8 @@ sub runAnnotationPipeline {
 	my $alignmentResult;	   
 
 	my $lengthFilters = [-26,25,0,0,0];
-	my $bwtCmd = "$bowtieBinary --threads $numCPU";
+	my $bwtCmd = "$bowtieBinary -a --best --strata --threads $numCPU";
+# change to use --best --strata -a based on http://rnajournal.cshlp.org/content/22/8/1120.full
 	if($phred64){
 		$bwtCmd = "$bwtCmd --phred64-quals";
 	}
@@ -347,6 +348,7 @@ sub runAnnotationPipeline {
 		# run alignment
 		print "Starting Annotation-$$annotNames[$i] ";
 		$$logHash{'annotStats'}[$i+1]{'cpuTime'} = time;
+        print STDERR "$$bwtCmdLines[$i]\n";
 		$alignmentStatus = system($$bwtCmdLines[$i]);
 		$$logHash{'annotStats'}[$i+1]{'cpuTime'} = time - $$logHash{'annotStats'}[$i+1]{'cpuTime'}; # in seconds
 		$alignmentStatus = $alignmentStatus >> 8;

--- a/miRge.pl
+++ b/miRge.pl
@@ -698,7 +698,7 @@ sub writeDataToCSV {
 	open $fh, ">", $mappedFile;
 	print $fh "uniqueSequence, annotFlag, $$annotNames[0], $$annotNames[1], $$annotNames[2], $$annotNames[3], $$annotNames[4]";
 	for ($i=0;$i<scalar(@sampleFiles);$i++) {
-		print $fh ", $sampleFiles[$i]";
+		print $fh ", $sampleNames[$i]";
 	}
 	print $fh "\n";
 	# a hash to compare isomirs to their parent mirnas across samples
@@ -841,7 +841,7 @@ sub writeDataToCSV {
 	open $fh, ">", $unmappedFile;
 	print $fh "uniqueSequence, annotFlag, $$annotNames[0], $$annotNames[1], $$annotNames[2], $$annotNames[3], $$annotNames[4]";
 	for ($i=0;$i<scalar(@sampleFiles);$i++) {
-			print $fh ", $sampleFiles[$i]";
+			print $fh ", $sampleNames[$i]";
 		}
 	print $fh "\n";
 	foreach $seqKey (keys %{$seqHash}) {


### PR DESCRIPTION
Several proposed changes to miRge. 

1) Add Table to HTML (report.html) file which lists the output files from miRge. This allows the HTML file to be the sole output in Galaxy (rather than having several outputs)
2) Allow separate naming of input samples rather than using their file names. This changes the names in the plots and the HTML table. Default behavior is unchanged
3) Allow user to specify specific HTML file output name. This allows use of miRge within Galaxy. Default behavior is unchanged
4) Change bowtie parameters to use --best and --strata according to literature
5) Do not exit if no miRNAs found, print warning instead. Useful when running negative controls which shouldn't have miRNAs
6) Add separate 5' and 3' adapter trimming step and associated parameters. This is necessary to use miRge with kits such as Bioo Scientific NEXTflex™ Small RNA Sequencing Kit v3